### PR TITLE
Allow package to be built by create_react_app

### DIFF
--- a/action_cable_react_jwt.js
+++ b/action_cable_react_jwt.js
@@ -4,8 +4,8 @@
             var slice = [].slice;
 
             global.document = {
-                addEventListener () {},
-                removeEventListener () {}
+                addEventListener: function() {},
+                removeEventListener: function() {}
             }
 
             this.ActionCable = {


### PR DESCRIPTION
Declaring these functions with the ES6 shorthand syntax seems to cause issues for `create_react_app` buildling and uglifying the JS. It could be handled by adding a babel transform, but for this trivial usage it seems cleaner to allow it to be handled without requiring the user to eject from the default babel config.