### PR TITLE
Fix ApplicationCable::Connection class error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ module ApplicationCable
 
     def find_verified_user
       begin
-        header_array = self.request.headers[:HTTP_SEC_WEBSOCKET_PROTOCOL].split(',')
+        header_array = request.headers[:HTTP_SEC_WEBSOCKET_PROTOCOL].split(',')
         token = header_array[header_array.length-1]
         decoded_token = JWT.decode token, Rails.application.secrets.secret_key_base, true, { :algorithm => 'HS256' }
         if (current_user = User.find((decoded_token[0])['sub']))


### PR DESCRIPTION
The Rails 5.1.x change request method from protected to private. There are  commit [91fa2b7](https://github.com/rails/rails/commit/91fa2b71c3fecb26a1dc7836874478f12e6d7a02#diff-e7a49345fe344d173cbcd874c21a1a61l)