### PR TITLE
Update readme to strip spaces from token

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module ApplicationCable
       begin
         header_array = self.request.headers[:HTTP_SEC_WEBSOCKET_PROTOCOL].split(',')
         token = header_array[header_array.length-1]
-        decoded_token = JWT.decode token, Rails.application.secrets.secret_key_base, true, { :algorithm => 'HS256' }
+        decoded_token = JWT.decode token.strip, Rails.application.secrets.secret_key_base, true, { :algorithm => 'HS256' }
         if (current_user = User.find((decoded_token[0])['sub']))
           current_user
         else


### PR DESCRIPTION
I ran across this while implementing this library. If pulling the token from local storage there can be leading spaces that will break the decoder. Also, I have this fully working on Angular so it might be doing a disservice just labeling it as react. Thanks for the library.