### PR TITLE
 Remove unused listener functions to allow trivial create_react_app builds

### DIFF
--- a/action_cable_react_jwt.js
+++ b/action_cable_react_jwt.js
@@ -3,10 +3,7 @@
         (function() {
             var slice = [].slice;
 
-            global.document = {
-                addEventListener: function() {},
-                removeEventListener: function() {}
-            }
+            global.document = { }
 
             this.ActionCable = {
                 INTERNAL: {


### PR DESCRIPTION
Having these empty function declarations causes https://github.com/facebook/create-react-app to fail to build