### PR TITLE
Make sure that we use the jwt as protocol only if it exists

### DIFF
--- a/action_cable_react_jwt.js
+++ b/action_cable_react_jwt.js
@@ -241,7 +241,7 @@
                         if (this.webSocket != null) {
                             this.uninstallEventHandlers();
                         }
-                        this.webSocket = new WebSocket(this.consumer.url, protocols.concat(this.consumer.jwt));
+                        this.webSocket = new WebSocket(this.consumer.url, this.consumer.jwt ? protocols.concat(this.consumer.jwt) : protocols);
                         this.webSocket.protocol = 'actioncable-v1-json';
                         this.installEventHandlers();
                         this.monitor.start();


### PR DESCRIPTION
I provide this fix for the Android case. If one does not provide a jwt, the ActionCable connection open fails.